### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -1,5 +1,7 @@
 name: Build and Test
 on: [ push ]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/aoc-2022/security/code-scanning/2](https://github.com/forketyfork/aoc-2022/security/code-scanning/2)

To resolve the problem, we should explicitly add a `permissions:` block that limits the available GITHUB_TOKEN permissions. The most conservative setting is `contents: read`, which allows the workflow to read repository contents, enough for checking out source and running builds. This key can be added either at the workflow top level (applies to all jobs) or at the job level (applies only to the `build` job). For a workflow with one job it is clearer to add it at the workflow level, directly after the `name:` and `on:` blocks, before `jobs:`. No additional methods, imports, or definitions are needed—just the YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
